### PR TITLE
chore: update the step security allowlist

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -44,9 +44,16 @@ jobs:
 
     steps:
       - name: Install Security Agent
-        uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604 # v2.5.0
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            plugins.gradle.org:443
+            repo.maven.apache.org:443
+            scans-in.gradle.com:443
 
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/flow-publish-maven-central.yaml
+++ b/.github/workflows/flow-publish-maven-central.yaml
@@ -28,8 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Security Agent
-        uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604 # v2.5.0
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             github.com:443

--- a/.github/workflows/flow-publish-maven-central.yaml
+++ b/.github/workflows/flow-publish-maven-central.yaml
@@ -32,15 +32,16 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            artifactcache.actions.githubusercontent.com:443
-            downloads.gradle-dn.com:443
             github.com:443
+            artifactcache.actions.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            downloads.gradle-dn.com:443
             plugins.gradle.org:443
             plugins-artifacts.gradle.org:443
             repo.gradle.org:443
-            repo.maven.apache.org:443
             scans-in.gradle.com:443
             services.gradle.org:443
+            repo.maven.apache.org:443
             s01.oss.sonatype.org:443
             jcenter.bintray.com:443
 

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -34,8 +34,9 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            downloads.gradle.org:443
             github.com:443
+            objects.githubusercontent.com:443
+            downloads.gradle.org:443
             jcenter.bintray.com:443
             plugins-artifacts.gradle.org:443
             plugins.gradle.org:443

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -30,8 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Security Agent
-        uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604 # v2.5.0
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             github.com:443


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the step security allowlist to permit `objects.githubusercontent.com:443` access.