### PR TITLE
chore: downgrade log4j2 version and convert unit tests to a module

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
             version("assertj-version", "3.24.2")
             version("slf4j-version", "2.0.7")
             version("logback-version", "1.4.14")
-            version("log4j-version", "2.22.0")
+            version("log4j-version", "2.20.0")
             version("junit-jupiter-version", "5.10.1")
             version("junit-platform-version", "1.10.1")
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -11,6 +11,10 @@ import org.junit.jupiter.api.extension.Extension;
 module com.jcovalent.junit.logging {
     exports com.jcovalent.junit.logging;
     exports com.jcovalent.junit.logging.assertj;
+    exports com.jcovalent.junit.logging.logback to
+            com.jcovalent.junit.logging.test;
+    exports com.jcovalent.junit.logging.utils to
+            com.jcovalent.junit.logging.test;
 
     opens com.jcovalent.junit.logging.extensions to
             org.junit.platform.commons;

--- a/src/test/java/com/jcovalent/junit/logging/test/LogEntryBuilderTest.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/LogEntryBuilderTest.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging;
+package com.jcovalent.junit.logging.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jcovalent.junit.logging.LogEntry;
+import com.jcovalent.junit.logging.LogEntryBuilder;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;

--- a/src/test/java/com/jcovalent/junit/logging/test/LoggingOutputTest.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/LoggingOutputTest.java
@@ -13,15 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging;
+package com.jcovalent.junit.logging.test;
 
-import static com.jcovalent.junit.logging.utils.TestUtils.safeAssertEmptyOutput;
-import static com.jcovalent.junit.logging.utils.TestUtils.safeAssertOutputOfNItems;
+import static com.jcovalent.junit.logging.test.utils.TestUtils.safeAssertEmptyOutput;
+import static com.jcovalent.junit.logging.test.utils.TestUtils.safeAssertOutputOfNItems;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jcovalent.junit.logging.JCovalentLoggingSupport;
+import com.jcovalent.junit.logging.LogEntryBuilder;
+import com.jcovalent.junit.logging.LoggingOutput;
+import com.jcovalent.junit.logging.LoggingOutputScope;
 import com.jcovalent.junit.logging.assertj.LoggingOutputAssert;
 import com.jcovalent.junit.logging.logback.InMemoryLogStorage;
-import com.jcovalent.junit.logging.utils.Log4jExternalLoggers;
+import com.jcovalent.junit.logging.test.utils.Log4jExternalLoggers;
 import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;

--- a/src/test/java/com/jcovalent/junit/logging/test/extensions/Log4jFieldResolverTest.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/extensions/Log4jFieldResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 JCovalent
+ * Copyright (C) 2022-2023 JCovalent
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging.extensions;
+package com.jcovalent.junit.logging.test.extensions;
 
 import static com.jcovalent.junit.logging.utils.Utils.qualifiedMemberName;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/jcovalent/junit/logging/test/extensions/Log4jParameterResolverTest.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/extensions/Log4jParameterResolverTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging.extensions;
+package com.jcovalent.junit.logging.test.extensions;
 
 import static com.jcovalent.junit.logging.utils.Utils.qualifiedMemberName;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/jcovalent/junit/logging/test/extensions/Slf4jFieldResolverTest.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/extensions/Slf4jFieldResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 JCovalent
+ * Copyright (C) 2022-2023 JCovalent
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging.extensions;
+package com.jcovalent.junit.logging.test.extensions;
 
 import static com.jcovalent.junit.logging.utils.Utils.qualifiedMemberName;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/jcovalent/junit/logging/test/extensions/Slf4jParameterResolverTest.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/extensions/Slf4jParameterResolverTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging.extensions;
+package com.jcovalent.junit.logging.test.extensions;
 
 import static com.jcovalent.junit.logging.utils.Utils.qualifiedMemberName;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/jcovalent/junit/logging/test/utils/Log4jExternalLoggers.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/utils/Log4jExternalLoggers.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging.utils;
+package com.jcovalent.junit.logging.test.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/jcovalent/junit/logging/test/utils/TestUtils.java
+++ b/src/test/java/com/jcovalent/junit/logging/test/utils/TestUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jcovalent.junit.logging.utils;
+package com.jcovalent.junit.logging.test.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -1,0 +1,20 @@
+module com.jcovalent.junit.logging.test {
+    opens com.jcovalent.junit.logging.test.extensions to
+            org.junit.platform.commons,
+            com.jcovalent.junit.logging;
+    opens com.jcovalent.junit.logging.test.utils to
+            org.junit.platform.commons,
+            com.jcovalent.junit.logging;
+    opens com.jcovalent.junit.logging.test to
+            org.junit.platform.commons,
+            com.jcovalent.junit.logging;
+
+    requires ch.qos.logback.core;
+    requires ch.qos.logback.classic;
+    requires com.jcovalent.junit.logging;
+    requires org.junit.jupiter.api;
+    requires org.apache.logging.log4j;
+    requires org.apache.logging.slf4j;
+    requires org.slf4j;
+    requires org.assertj.core;
+}


### PR DESCRIPTION
## Description

This pull request changes the following:

- Converts the unit tests to a module.
- Downgrades the log4j2 version to address issues with log4j2 versions `>= 2.21.0` which breaks modular environments.

## Related Issues

- Closes #45 